### PR TITLE
Ensure is running on correct path

### DIFF
--- a/step.sh
+++ b/step.sh
@@ -25,10 +25,10 @@ fi
 print_configuration
 
 # Reseting the package
-swift package reset
+(cd "${PROJECT_DIR}" ; swift package reset)
 
 # Run test
-swift test --enable-code-coverage --parallel --xunit-output "${TEST_RESULT}"
+(cd "${PROJECT_DIR}" ; swift test --enable-code-coverage --parallel --xunit-output "${TEST_RESULT}")
 
 # Copy code coverage
 cp "$(swift test --show-codecov-path)" "${CODE_COVERAGE_RESULT}"


### PR DESCRIPTION
The `PROJECT_DIR` was not being used in the step. This PR ensures that the swift commands run in the specified folder.