### PR TITLE
Use xcodebuild to run the tests for better integration with xcpretty

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .bitrise*
 .gows.user.yml
 _tmp/.build
+*.xcresult

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Run Swift Test [![Build Status](https://app.bitrise.io/app/6db4b5a23df77ef3/status.svg?token=sh49ITq9wR-JvHYPuepTMA&branch=main)](https://app.bitrise.io/app/6db4b5a23df77ef3)
 
-Step that runs "swift test" in the local directory and export the results into Bitrise Test Plugin
+This step uses xcodebuild & xcpretty to run the macOS tests for the Swift Package Manager. The final files are output in a structure compatible with the "Test Report" plugin and can be configured to be JUnit or HTML as output, so the generated files are compatible with tools like Dagger.
+
+The Code coverage is always exported as a JSON file.
 
 ## How to use this Step
 
@@ -10,6 +12,8 @@ Step that runs "swift test" in the local directory and export the results into B
    inputs:
    - TEST_NAME: BitriseTest
    - PROJECT_DIR: $BITRISE_SOURCE_DIR
+   - SKIP_BUILD: 'NO'
+   - REPORTER: junit
 ```
 
 This step will run the package tests and expose the test result and code coverage on:

--- a/step.sh
+++ b/step.sh
@@ -5,12 +5,13 @@ set -e
 # Helper functions
 function print_configuration() {
     echo "Configuration:"
+    echo "PACKAGE_NAME: ${PACKAGE_NAME}"
     echo "PROJECT_DIR: ${PROJECT_DIR}"
     echo "TEST_NAME: ${TEST_NAME}"
-    echo "CONFIGURATION: ${CONFIGURATION}"
     echo "BUILD_PATH: ${BUILD_PATH}"
     echo "SKIP_BUILD: ${SKIP_BUILD}"
     echo "OUTPUT_DIR: ${OUTPUT_DIR}"
+    echo "REPORTER: ${REPORTER}"
     echo "TEST_RESULT: ${TEST_RESULT}"
     echo "CODE_COVERAGE_RESULT: ${CODE_COVERAGE_RESULT}"
 }
@@ -18,34 +19,73 @@ function print_configuration() {
 # Prepare environment
 # Creating the sub-directory for the test run within the BITRISE_TEST_RESULT_DIR:
 OUTPUT_DIR="${BITRISE_TEST_RESULT_DIR}/SwiftTest"
-TEST_RESULT="${OUTPUT_DIR}/${TEST_NAME}.xml"
-CODE_COVERAGE_RESULT="${OUTPUT_DIR}/${TEST_NAME}_codecoverage.json"
+CODE_COVERAGE_FILE_NAME="${TEST_NAME}_codecoverage.json"
+CODE_COVERAGE_RESULT="${OUTPUT_DIR}/${CODE_COVERAGE_FILE_NAME}"
+TEST_ARCHIVE="$(pwd)/test.xcresult"
 
 if [ ! -d "${OUTPUT_DIR}" ]; then
     mkdir "${OUTPUT_DIR}"
 fi
 
+if [ "${REPORTER}" = "junit" ]; then
+    TEST_FILE_NAME="${TEST_NAME}.xml"
+else
+    TEST_FILE_NAME="${TEST_NAME}.html"
+fi
+
+TEST_RESULT="${OUTPUT_DIR}/${TEST_FILE_NAME}"
+
+PACKAGE_NAME="$(cd "${PROJECT_DIR}" ; swift package describe --type text | \
+grep 'Name: ' | \
+head -1 | \
+sed -e 's/Name:[[:space:]]*//g')"
+
 print_configuration
 
-SKIP_BUILD_FLAG=""
+echo "Preparing environment"
+if [ -d "${TEST_ARCHIVE}" ]; then
+    rm -rf "${TEST_ARCHIVE}"
+fi
+if [ -f "${TEST_RESULT}" ]; then
+    rm "${TEST_RESULT}"
+fi
+if [ -f "${CODE_COVERAGE_RESULT}" ]; then
+    rm "${CODE_COVERAGE_RESULT}"
+fi
+
+RUN_ACTION=""
 if [ "${SKIP_BUILD}" = "YES" ]; then
-    SKIP_BUILD_FLAG="--skip-build"
+    RUN_ACTION="test-without-building"
+else
+    RUN_ACTION="test"
 fi
 
 echo "Running tests"
-BUILD_COMMAND="swift test ${SKIP_BUILD_FLAG} --enable-code-coverage --parallel --configuration ${CONFIGURATION} --xunit-output ${TEST_RESULT} --build-path ${BUILD_PATH}"
-echo "${BUILD_COMMAND}"
+BUILD_COMMAND="xcodebuild ${RUN_ACTION} \
+-scheme '${PACKAGE_NAME}' \
+-configuration 'Debug' \
+-enableCodeCoverage YES \
+-sdk macosx \
+-resultBundlePath '${TEST_ARCHIVE}' \
+-derivedDataPath '${BUILD_PATH}' \
+-destination 'platform=macOS' | \
+xcpretty --color --report '${REPORTER}' --output '${TEST_RESULT}'"
 (cd "${PROJECT_DIR}" ; sh -c "${BUILD_COMMAND}")
 
 # Copy code coverage
-cp "$(cd "${PROJECT_DIR}" ; swift test --show-codecov-path)" "${CODE_COVERAGE_RESULT}"
+(cd "${PROJECT_DIR}" ; xcrun xccov view --report --json "${TEST_ARCHIVE}" > "${CODE_COVERAGE_RESULT}")
 
 # Creating the test-info.json file with the name of the test run defined:
 echo "{\"test-name\":\"${TEST_NAME}\"}" >> "${OUTPUT_DIR}/test-info.json"
 
 # Exporting result to artefacts
-cp "${TEST_RESULT}" "${BITRISE_DEPLOY_DIR}/${TEST_NAME}.xml"
-cp "${CODE_COVERAGE_RESULT}" "${BITRISE_DEPLOY_DIR}/${TEST_NAME}_codecoverage.json"
+cp "${TEST_RESULT}" "${BITRISE_DEPLOY_DIR}/${TEST_FILE_NAME}"
+cp "${CODE_COVERAGE_RESULT}" "${BITRISE_DEPLOY_DIR}/${CODE_COVERAGE_FILE_NAME}"
 
-envman add --key "TEST_RESULT" --value "${BITRISE_DEPLOY_DIR}/${TEST_NAME}.xml"
-envman add --key "CODE_COVERAGE_RESULT" --value "${BITRISE_DEPLOY_DIR}/${TEST_NAME}_codecoverage.json"
+envman add --key "TEST_RESULT" --value "${BITRISE_DEPLOY_DIR}/${TEST_FILE_NAME}"
+envman add --key "CODE_COVERAGE_RESULT" --value "${BITRISE_DEPLOY_DIR}/${CODE_COVERAGE_FILE_NAME}"
+
+echo "Cleaning environment"
+if [ -d "${TEST_ARCHIVE}" ]; then
+    rm -rf "${TEST_ARCHIVE}"
+fi

--- a/step.yml
+++ b/step.yml
@@ -10,9 +10,12 @@
 title: |-
   Run Swift Test With Code Coverage
 summary: |
-  Step that runs SPM tests on macOS, outputting an XUnit XML file and Code Coverage
+  Step that runs SPM tests on macOS, outputting an XML/HTML test result file and Code Coverage JSON file
 description: |
-  Step that runs "swift test" in the local directory and export the results as a XUnit XML file into Bitrise Test Plugin and provides in the outputs the Code Coverage JSON file
+  This step uses xcodebuild & xcpretty to run the macOS tests for the Swift Package Manager. The final files are
+  output in a structure compatible with the "Test Report" plugin and can be configured to be JUnit or HTML as output,
+  so the generated files are compatible with tools like Dagger.
+  The Code coverage is always exported as a JSON file.
 website: https://github.com/igorcferreira/bitrise-step-run-spm-test-with-coverage
 source_code_url: https://github.com/igorcferreira/bitrise-step-run-spm-test-with-coverage
 support_url: https://github.com/igorcferreira/bitrise-step-run-spm-test-with-coverage/issues
@@ -29,7 +32,6 @@ host_os_tags:
 # https://github.com/bitrise-io/bitrise/blob/master/_docs/step-development-guideline.md
 #
 project_type_tags:
-  - ios
   - macos
 #   - android
 #   - xamarin
@@ -77,28 +79,6 @@ inputs:
         Name that will be used in the test information and generated files
       is_expand: true
       is_required: true
-  - CONFIGURATION: "debug"
-    opts:
-      title: "Build Configuration"
-      summary: "Allows setting either Release or Debug for the build action"
-      description: |
-        Allows setting either Release or Debug for the build action
-      is_expand: true
-      is_required: true
-      value_options:
-      - release
-      - debug
-  - SKIP_BUILD: "NO"
-    opts:
-      title: "Run test without building"
-      summary: "Run test without building"
-      description: |
-        Sends a --skip-build flag into the `swift test` command
-      is_expand: true
-      is_required: true
-      value_options:
-      - 'YES'
-      - 'NO'
   - BUILD_PATH: $BITRISE_SOURCE_DIR/.build
     opts:
       title: "Build path"
@@ -107,6 +87,40 @@ inputs:
         Path where the build files will be stored
       is_expand: true
       is_required: true
+  - CONFIGURATION: "debug"
+    opts:
+      deprecated: true
+      title: "Build Configuration (Deprecated)"
+      summary: "Allows setting either Release or Debug for the build action (Deprecated)"
+      description: |
+        Allows setting either Release or Debug for the build action (Deprecated)
+      is_expand: true
+      is_required: false
+      value_options:
+      - release
+      - debug
+  - SKIP_BUILD: "NO"
+    opts:
+      title: "Run test without building"
+      summary: "Run test without building"
+      description: |
+        Run test without building
+      is_expand: true
+      is_required: true
+      value_options:
+      - 'YES'
+      - 'NO'
+  - REPORTER: 'junit'
+    opts:
+      title: "xcpretty reporter"
+      summary: "Choose between a junit report or a html report"
+      description: |
+        Choose between a junit report or a html report
+      is_expand: true
+      is_required: true
+      value_options:
+      - junit
+      - html
 
 outputs:
   - TEST_RESULT:


### PR DESCRIPTION
The `swift test` command output cannot be fully translated by xcpretty. This changes the test engine from `swift test` to `xcodebuild test`, to better integrate with tools like Dagger.